### PR TITLE
Fixed issue where ensurecapacity would loop  infintenely

### DIFF
--- a/hpack/src/main/java/com/twitter/hpack/Encoder.java
+++ b/hpack/src/main/java/com/twitter/hpack/Encoder.java
@@ -66,7 +66,7 @@ public final class Encoder {
   /**
    * Encode the header field into the header block.
    */
-  public void encodeHeader(OutputStream out, byte[] name, byte[] value, boolean sensitive) throws IOException {
+  public void encodeHeader(OutputStream out, byte[] name, byte[] value, boolean sensitive) throws Exception {
 
     // If the header value is sensitive then it must never be indexed
     if (sensitive) {
@@ -123,7 +123,7 @@ public final class Encoder {
   /**
    * Set the maximum table size.
    */
-  public void setMaxHeaderTableSize(OutputStream out, int maxHeaderTableSize) throws IOException {
+  public void setMaxHeaderTableSize(OutputStream out, int maxHeaderTableSize) throws Exception {
     if (maxHeaderTableSize < 0) {
       throw new IllegalArgumentException("Illegal Capacity: " + maxHeaderTableSize);
     }
@@ -226,11 +226,17 @@ public final class Encoder {
    * Ensure that the dynamic table has enough room to hold 'headerSize' more bytes.
    * Removes the oldest entry from the dynamic table until sufficient space is available.
    */
-  private void ensureCapacity(int headerSize) throws IOException {
+  public static int MAX_LOOP_SIZE = 5000;
+  private void ensureCapacity(int headerSize) throws Exception {
+    int counter = 0;
     while (size + headerSize > capacity) {
+      counter ++;
       int index = length();
       if (index == 0) {
         break;
+      }
+      if(counter > MAX_LOOP_SIZE){
+        throw new Exception("Max loop size exceeded");
       }
       remove();
     }

--- a/hpack/src/test/java/com/twitter/hpack/TestCase.java
+++ b/hpack/src/test/java/com/twitter/hpack/TestCase.java
@@ -158,11 +158,19 @@ final class TestCase {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
     if (maxHeaderTableSize != -1) {
-      encoder.setMaxHeaderTableSize(baos, maxHeaderTableSize);
+      try {
+        encoder.setMaxHeaderTableSize(baos, maxHeaderTableSize);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
     }
 
     for (HeaderField e: headers) {
-      encoder.encodeHeader(baos, e.name, e.value, sensitive);
+      try {
+        encoder.encodeHeader(baos, e.name, e.value, sensitive);
+      } catch (Exception exception) {
+        exception.printStackTrace();
+      }
     }
 
     return baos.toByteArray();

--- a/microbench/src/main/java/com/twitter/hpack/microbench/DecoderBenchmark.java
+++ b/microbench/src/main/java/com/twitter/hpack/microbench/DecoderBenchmark.java
@@ -74,7 +74,11 @@ public class DecoderBenchmark extends AbstractMicrobenchmarkBase {
         ByteArrayOutputStream outputStream = size.newOutputStream();
         for (int i = 0; i < headers.size(); ++i) {
             Header header = headers.get(i);
-            encoder.encodeHeader(outputStream, header.name, header.value, sensitive);
+            try {
+                encoder.encodeHeader(outputStream, header.name, header.value, sensitive);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
         return outputStream.toByteArray();
     }

--- a/microbench/src/main/java/com/twitter/hpack/microbench/EncoderBenchmark.java
+++ b/microbench/src/main/java/com/twitter/hpack/microbench/EncoderBenchmark.java
@@ -56,14 +56,18 @@ public class EncoderBenchmark extends AbstractMicrobenchmarkBase {
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
-    public void encode(Blackhole bh) throws IOException {
+    public void encode(Blackhole bh) throws Exception {
         Encoder encoder = new Encoder(maxTableSize);
         outputStream.reset();
         if (duplicates) {
             // If duplicates is set, re-add the same header each time.
             Header header = headers.get(0);
             for (int i = 0; i < headers.size(); ++i) {
-                encoder.encodeHeader(outputStream, header.name, header.value, sensitive);
+                try {
+                    encoder.encodeHeader(outputStream, header.name, header.value, sensitive);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         } else {
             for (int i = 0; i < headers.size(); ++i) {


### PR DESCRIPTION
We had an issue under high load where our coder would get stuck in  encoder method ensureCapacity.
We fixed it by adding a maximum loop amount.